### PR TITLE
Fix: Catch difference between topology and trajectory

### DIFF
--- a/src/kimmdy_hat/reaction.py
+++ b/src/kimmdy_hat/reaction.py
@@ -124,9 +124,9 @@ class HAT_reaction(ReactionPlugin):
             u.load_new(trajectory_path.as_posix())
         except ValueError:
             if u.trajectory.n_atoms > len(u.atoms):
-                raise ValueError(f"More atoms in {self.trajectory_format} file than in topology. Check compressed-x-grps is set to 'Protein' in .mdp files.")
+                raise ValueError(f"More atoms in {self.trajectory_format} file than in topology. Check compressed-x-grps is set to the correct group in .mdp files.")
             elif u.trajectory.n_atoms < len(u.atoms):
-                raise ValueError(f"Less atoms in {self.trajectory_format} file than in topology. Check compress-x-grps is set to the correct group.")
+                raise ValueError(f"Less atoms in {self.trajectory_format} file than in topology. Check compressed-x-grps is set to the correct group in .mdp files.")
 
 
         # add necessary attributes


### PR DESCRIPTION
When runnning witht the previous files example, there was a typo in which the .mdp files were using 'System' instead of 'Protein' for `compressed-x-grps`. This would result in MDAnalysis raising a ValueError due to a mismatch in the .xtc file and the isolated protein structure. 
The ValueError has been rephrased to advise the user to check the value of `compressed-x-grps` in their .mdp files.