### PR TITLE
Fix: Free GPU memory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "numpy<1.24",
   "kgcnn==2.1.0",
   "MDAnalysis>=2.5.0",
-  "tensorflow<2.16",
+  "tensorflow[and-cuda]<2.16",
   "kimmdy",
 ]
 

--- a/src/kimmdy_hat/reaction.py
+++ b/src/kimmdy_hat/reaction.py
@@ -180,7 +180,7 @@ class HAT_reaction(ReactionPlugin):
             # Create multiprocessing Process to ensure memory is freed after prediction
 
             pool = Pool(processes=1) # only 1 needed
-            result = pool.apply(make_predictions,args=([u]),**kwargs)
+            result = pool.apply(make_predictions,args=([u]),kwds=kwargs)
 
             # Get receipe collection from result
             recipe_collection = result.get()[0]

--- a/src/kimmdy_hat/reaction.py
+++ b/src/kimmdy_hat/reaction.py
@@ -165,7 +165,6 @@ class HAT_reaction(ReactionPlugin):
 
             kwargs = {
                 "se_dir": se_dir,
-                "hparas": self.hparas,
                 "prediction_scheme": self.prediction_scheme,
                 "R": self.R,
                 "temperature": self.temperature,
@@ -203,7 +202,6 @@ class HAT_reaction(ReactionPlugin):
 def make_predictions(
     u: MDA.Universe,
     se_dir,
-    hparas,
     prediction_scheme,
     R,
     temperature,

--- a/src/kimmdy_hat/reaction.py
+++ b/src/kimmdy_hat/reaction.py
@@ -19,6 +19,7 @@ import shutil
 from pathlib import Path
 from tqdm.autonotebook import tqdm
 
+
 class HAT_reaction(ReactionPlugin):
     def __init__(self, *args, **kwargs):
 
@@ -187,6 +188,7 @@ class HAT_reaction(ReactionPlugin):
             se_tmpdir.cleanup()
 
         return recipe_collection
+
 
 @free_gpu
 def make_predictions(

--- a/src/kimmdy_hat/utils/utils.py
+++ b/src/kimmdy_hat/utils/utils.py
@@ -143,9 +143,9 @@ def free_gpu(func):
                     kwargs=kwargs)
         p.start()
         p.join()
-        res = q.get()
-        q.close()
+        res = q.get(block=True,timeout=100)
         p.close()
+        q.close()
         return res
 
     return wrapper

--- a/src/kimmdy_hat/utils/utils.py
+++ b/src/kimmdy_hat/utils/utils.py
@@ -2,6 +2,7 @@ import MDAnalysis as mda
 import numpy as np
 from multiprocessing import Process, Queue
 
+
 def find_radicals(u):
     """
     finds radicals in a MDAnalysis universe
@@ -129,21 +130,21 @@ def check_cylinderclash(a, b, t, r_min=0.8, d_min=None, verbose=False):
     else:
         raise ValueError(f"Type/Shape of t wrong: {t}")
 
+
 # Decorator and helper function to free the gpu
 def _queue_helper(func, q, *args, **kwargs):
     res = func(*args, **kwargs)
     q.put(res)
 
+
 def free_gpu(func):
 
     def wrapper(*args, **kwargs):
         q = Queue(1)
-        p = Process(target=_queue_helper,
-                    args = (func, q, *args),
-                    kwargs=kwargs)
+        p = Process(target=_queue_helper, args=(func, q, *args), kwargs=kwargs)
         p.start()
         p.join()
-        res = q.get(block=True,timeout=100)
+        res = q.get(block=True, timeout=100)
         p.close()
         q.close()
         return res

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,13 @@ def pytest_addoption(parser):
     parser.addoption('--gpu',action='store_true',dest="gpu",
                      default=False, help="enable gpu memory release tests")
     
-@pytest.fixture
-def gpu(request):
-    return request.config.getoption("--gpu")
+def pytest_configure(config):
+    config.addininvalue_line("markers","gpu: mark test to be ran on GPU")
+
+def pytest_collection_modifyitems(config,items):
+    if config.getoption("--gpu"):
+        return
+    skip_gpu = pytest.mark.skip(reason="need --gpu option to run")
+    for item in items:
+        if "gpu" in item.keywords:
+            item.add_marker(skip_gpu)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption('--gpu',action='store_true',dest="gpu",
+                     default=False, help="enable gpu memory release tests")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,21 @@
 import pytest
 
-def pytest_addoption(parser):
-    parser.addoption('--gpu',action='store_true',dest="gpu",
-                     default=False, help="enable gpu memory release tests")
-    
-def pytest_configure(config):
-    config.addinivalue_line("markers","gpu: mark test to be ran on GPU")
 
-def pytest_collection_modifyitems(config,items):
+def pytest_addoption(parser):
+    parser.addoption(
+        "--gpu",
+        action="store_true",
+        dest="gpu",
+        default=False,
+        help="enable gpu memory release tests",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "gpu: mark test to be ran on GPU")
+
+
+def pytest_collection_modifyitems(config, items):
     if config.getoption("--gpu"):
         return
     skip_gpu = pytest.mark.skip(reason="need --gpu option to run")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,3 +3,7 @@ import pytest
 def pytest_addoption(parser):
     parser.addoption('--gpu',action='store_true',dest="gpu",
                      default=False, help="enable gpu memory release tests")
+    
+@pytest.fixture
+def gpu(request):
+    return request.config.getoption("--gpu")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ def pytest_addoption(parser):
                      default=False, help="enable gpu memory release tests")
     
 def pytest_configure(config):
-    config.addininvalue_line("markers","gpu: mark test to be ran on GPU")
+    config.addinivalue_line("markers","gpu: mark test to be ran on GPU")
 
 def pytest_collection_modifyitems(config,items):
     if config.getoption("--gpu"):

--- a/tests/test_traj.py
+++ b/tests/test_traj.py
@@ -6,9 +6,6 @@ from pprint import pprint
 import logging
 import tensorflow as tf
 
-# pytest decorator to have gpu checks off by default 
-#gpu = pytest.mark.skipif("not config.getoption('gpu')")
-
 # %%
 class DummyClass:
     logger = logging.getLogger()

--- a/tests/test_traj.py
+++ b/tests/test_traj.py
@@ -4,7 +4,10 @@ from kimmdy_hat import HAT_reaction
 import pytest
 from pprint import pprint
 import logging
+import tensorflow as tf
 
+# pytest decorator to have gpu checks off by default 
+gpu = pytest.mark.skipif("not config.getoption('gpu')")
 
 # %%
 class DummyClass:
@@ -140,6 +143,11 @@ def test_traj_to_recipes(recipe_collection):
         assert len(recipe.rates) in [3, 6]
         assert len(recipe.timespans) in [3, 6]
 
+@gpu
+def gpu_release_recipe_collection(recipe_collection):
+    print(recipe_collection.recipes)
+    assert 'GPU' in [device.device_type for device in tf.config.list_physical_devices]
+    assert tf.config.experimental.get_memory_usage('GPU:0') == 0
 
 @pytest.fixture
 def recipe_collection_pbc(tmpdir):

--- a/tests/test_traj.py
+++ b/tests/test_traj.py
@@ -7,7 +7,7 @@ import logging
 import tensorflow as tf
 
 # pytest decorator to have gpu checks off by default 
-gpu = pytest.mark.skipif("not config.getoption('gpu')")
+#gpu = pytest.mark.skipif("not config.getoption('gpu')")
 
 # %%
 class DummyClass:
@@ -143,7 +143,7 @@ def test_traj_to_recipes(recipe_collection):
         assert len(recipe.rates) in [3, 6]
         assert len(recipe.timespans) in [3, 6]
 
-@gpu
+@pytest.mark.gpu
 def gpu_release_recipe_collection(recipe_collection):
     print(recipe_collection.recipes)
     assert 'GPU' in [device.device_type for device in tf.config.list_physical_devices]

--- a/tests/test_traj.py
+++ b/tests/test_traj.py
@@ -141,7 +141,6 @@ def test_traj_to_recipes(recipe_collection):
         assert len(recipe.timespans) in [3, 6]
 
 @pytest.fixture
-@pytest.mark.gpu
 def gpu_info(recipe_collection):
     gpu_list = subprocess.check_output('nvidia-smi -L',shell=True)
     gpu_mem = subprocess.check_output('nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits', shell=True)

--- a/tests/test_traj.py
+++ b/tests/test_traj.py
@@ -5,9 +5,6 @@ import pytest
 from pprint import pprint
 import logging
 import subprocess
-import os
-
-os.environ['KMP_DUPLICATE_LIB_OK'] = 'True'
 
 # %%
 class DummyClass:

--- a/tests/test_traj.py
+++ b/tests/test_traj.py
@@ -144,7 +144,7 @@ def test_traj_to_recipes(recipe_collection):
         assert len(recipe.timespans) in [3, 6]
 
 @pytest.mark.gpu
-def gpu_release_recipe_collection(recipe_collection):
+def test_gpu_memory_release(recipe_collection):
     print(recipe_collection.recipes)
     assert 'GPU' in [device.device_type for device in tf.config.list_physical_devices]
     assert tf.config.experimental.get_memory_usage('GPU:0') == 0

--- a/tests/test_traj.py
+++ b/tests/test_traj.py
@@ -6,6 +6,7 @@ from pprint import pprint
 import logging
 import subprocess
 
+
 # %%
 class DummyClass:
     logger = logging.getLogger()
@@ -140,16 +141,21 @@ def test_traj_to_recipes(recipe_collection):
         assert len(recipe.rates) in [3, 6]
         assert len(recipe.timespans) in [3, 6]
 
+
 @pytest.fixture
 def gpu_info(recipe_collection):
-    gpu_list = subprocess.check_output('nvidia-smi -L',shell=True)
-    gpu_mem = subprocess.check_output('nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits', shell=True)
-    return [gpu_list.decode('utf-8').rstrip(),int(gpu_mem.decode('utf-8').rstrip())]
+    gpu_list = subprocess.check_output("nvidia-smi -L", shell=True)
+    gpu_mem = subprocess.check_output(
+        "nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits", shell=True
+    )
+    return [gpu_list.decode("utf-8").rstrip(), int(gpu_mem.decode("utf-8").rstrip())]
+
 
 @pytest.mark.gpu
 def test_gpu_memory_release(gpu_info):
-    assert 'GPU' in gpu_info[0]
+    assert "GPU" in gpu_info[0]
     assert gpu_info[1] == 0
+
 
 @pytest.fixture
 def recipe_collection_pbc(tmpdir):
@@ -184,4 +190,3 @@ def test_traj_to_recipes_pbc(recipe_collection_pbc):
     for recipe in recipe_collection_pbc.recipes:
         assert len(recipe.rates) in [18, 8]
         assert len(recipe.timespans) in [18, 8]
-

--- a/tests/test_traj.py
+++ b/tests/test_traj.py
@@ -146,7 +146,7 @@ def test_traj_to_recipes(recipe_collection):
 @pytest.mark.gpu
 def test_gpu_memory_release(recipe_collection):
     print(recipe_collection.recipes)
-    assert 'GPU' in [device.device_type for device in tf.config.list_physical_devices]
+    assert 'GPU' in [device.device_type for device in tf.config.list_physical_devices()]
     assert tf.config.experimental.get_memory_usage('GPU:0') == 0
 
 @pytest.fixture

--- a/tests/test_traj.py
+++ b/tests/test_traj.py
@@ -141,6 +141,7 @@ def test_traj_to_recipes(recipe_collection):
         assert len(recipe.timespans) in [3, 6]
 
 @pytest.fixture
+@pytest.mark.gpu
 def gpu_info(recipe_collection):
     gpu_list = subprocess.check_output('nvidia-smi -L',shell=True)
     gpu_mem = subprocess.check_output('nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits', shell=True)

--- a/tests/test_traj.py
+++ b/tests/test_traj.py
@@ -143,12 +143,6 @@ def test_traj_to_recipes(recipe_collection):
         assert len(recipe.rates) in [3, 6]
         assert len(recipe.timespans) in [3, 6]
 
-@pytest.mark.gpu
-def test_gpu_memory_release(recipe_collection):
-    print(recipe_collection.recipes)
-    assert 'GPU' in [device.device_type for device in tf.config.list_physical_devices()]
-    assert tf.config.experimental.get_memory_usage('GPU:0') == 0
-
 @pytest.fixture
 def recipe_collection_pbc(tmpdir):
     plgn = HAT_reaction("Hat_reaction", DummyRunmanager())
@@ -182,3 +176,9 @@ def test_traj_to_recipes_pbc(recipe_collection_pbc):
     for recipe in recipe_collection_pbc.recipes:
         assert len(recipe.rates) in [18, 8]
         assert len(recipe.timespans) in [18, 8]
+
+@pytest.mark.gpu
+def test_gpu_memory_release(recipe_collection):
+    print(recipe_collection.recipes)
+    assert 'GPU' in [device.device_type for device in tf.config.list_physical_devices()]
+    assert tf.config.experimental.get_memory_usage('GPU:0') == 0


### PR DESCRIPTION
Implamented a fix to free the GPU memory after the `make_predictions` step of the kimmdy-hat is completed. This was achieved by moving the loading of the Tensorflow models from the `__init__` into `make_predicitions`. An utility decorator was made with multiprocessing functions to make `make_predictions` run on a single, seperate process. Once this process is complete, any memory used is immediately freed after completion. 
Whilst this fix does increase the overhead slightly (~23 seconds per HAT reaction call), this still considerably smaller than the typical time requied for each molecular dynamics step.
Within the pytest frame, work a test has been made to ensure that the GPU memory is freed after the HAT reaction has completed. This test can be performed with the additional flag `--gpu`.

Known issues:
- ~~If there is test conducted after the GPU test runs, the test breaks and causes the pytest to hang. This seems to be an issue with multiprocessing. Still trying to rectify.~~ Fixed with latest push.