### PR TITLE
feat: download models from github

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-graft src
-graft tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,5 +41,18 @@ include-package-data = true
 where = ["src"]
 namespaces = false
 
+[tool.setuptools.package-data]
+kimmdy_hat = ["*.json"]
+
+[tool.setuptools.exclude-package-data]
+HATmodels = ["*_models"]
+
 [dependency-groups]
-dev = ["pytest", "pytest-cov", "black", "hypothesis", "nglview"]
+dev = [
+  "pytest",
+  "pytest-cov",
+  "pytest-mock",
+  "black",
+  "hypothesis",
+  "nglview"
+]

--- a/src/kimmdy_hat/__init__.py
+++ b/src/kimmdy_hat/__init__.py
@@ -1,1 +1,6 @@
 from kimmdy_hat.reaction import HAT_reaction
+from kimmdy_hat.utils.model_downloader import (
+    ensure_models_exist as _ensure_models_exist,
+)
+
+_ensure_models_exist()

--- a/src/kimmdy_hat/utils/model_downloader.py
+++ b/src/kimmdy_hat/utils/model_downloader.py
@@ -28,9 +28,9 @@ def download_models(target_dir):
     for model in MODELS:
         model_paths.extend(list(unzipped.glob(f"**/{model}")))
 
-    assert len(MODELS) == len(model_paths), (
-        f"Not all models could be downloaded, found: {model_paths}"
-    )
+    assert len(MODELS) == len(
+        model_paths
+    ), f"Not all models could be downloaded, found: {model_paths}"
 
     for model in model_paths:
         logger.debug(f"Copy {model.name} to {target_dir}")

--- a/src/kimmdy_hat/utils/model_downloader.py
+++ b/src/kimmdy_hat/utils/model_downloader.py
@@ -1,0 +1,58 @@
+import logging
+from urllib.request import urlretrieve
+from pathlib import Path
+from shutil import copytree, rmtree
+import zipfile
+
+
+URL = "https://github.com/graeter-group/kimmdy-hat/archive/refs/tags/v0.1.1.zip"
+MODELS = [
+    "classic_models",
+    "grappa_models",
+]
+logger = logging.getLogger(__name__)
+
+
+def download_models(target_dir):
+    logger.info("Starting to download HAT prediction models..")
+    tmp_path, header = urlretrieve(URL)
+    tmp_path = Path(tmp_path)
+    logger.info("Download finished!")
+    logger.debug(f"Zip archive: {tmp_path}")
+
+    unzipped = tmp_path.parent / "HATmodels"
+    with zipfile.ZipFile(tmp_path, "r") as zip_f:
+        zip_f.extractall(unzipped)
+
+    model_paths = []
+    for model in MODELS:
+        model_paths.extend(list(unzipped.glob(f"**/{model}")))
+
+    assert len(MODELS) == len(model_paths), (
+        f"Not all models could be downloaded, found: {model_paths}"
+    )
+
+    for model in model_paths:
+        logger.debug(f"Copy {model.name} to {target_dir}")
+        copytree(model, target_dir / model.name)
+
+    tmp_path.unlink()
+    rmtree(unzipped)
+    logger.debug("Removed downloads")
+
+
+def ensure_models_exist():
+    models_path = Path(__file__).parent.parent.parent / "HATmodels"
+    existing = [(models_path / m).exists() for m in MODELS]
+    download = False
+    if all(existing):
+        logger.info("Found all expected HAT models.")
+    elif any(existing):
+        logger.info("HAT Models download not complete.")
+        download = True
+    else:
+        logger.info("HAT models not downloaded yet.")
+        download = True
+
+    if download:
+        download_models(models_path)

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from kimmdy_hat.utils.model_downloader import (
+    download_models,
+    ensure_models_exist,
+    MODELS,
+)
+import zipfile
+import pytest
+
+
+def zip_dummy(tmp_path: Path, directories: list[Path]):
+    for c in directories:
+        (tmp_path / c).mkdir()
+        to_write = tmp_path / c / "dummy.txt"
+        to_write.touch()
+        with zipfile.ZipFile(tmp_path / "arch.zip", "a") as zip_f:
+            zip_f.write(to_write)
+    return tmp_path / "arch.zip"
+
+
+def test_download_models(mocker, tmp_path):
+    contents = [Path(m) for m in MODELS]
+    archive = zip_dummy(tmp_path, contents)
+
+    urlret_mock = mocker.patch("kimmdy_hat.utils.model_downloader.urlretrieve")
+    urlret_mock.return_value = (archive, "header")
+
+    download_models(tmp_path / "target")
+
+    for m in MODELS:
+        assert len(list((tmp_path / "target").glob(m))) == 1
+
+
+def test_ensure_models_exist_all(mocker):
+    downloader = mocker.patch("kimmdy_hat.utils.model_downloader.download_models")
+    mock_all = mocker.patch("kimmdy_hat.utils.model_downloader.all")
+    mock_all.return_value = True
+    ensure_models_exist()
+    downloader.assert_not_called()
+
+
+def test_ensure_models_exist_any(mocker):
+    downloader = mocker.patch("kimmdy_hat.utils.model_downloader.download_models")
+    mock_all = mocker.patch("kimmdy_hat.utils.model_downloader.all")
+    mock_all.return_value = False
+    mock_any = mocker.patch("kimmdy_hat.utils.model_downloader.any")
+    mock_any.return_value = True
+    ensure_models_exist()
+    downloader.assert_called_once()
+
+
+def test_ensure_models_exist_none(mocker):
+    downloader = mocker.patch("kimmdy_hat.utils.model_downloader.download_models")
+    mock_all = mocker.patch("kimmdy_hat.utils.model_downloader.all")
+    mock_all.return_value = False
+    mock_any = mocker.patch("kimmdy_hat.utils.model_downloader.any")
+    mock_any.return_value = False
+    ensure_models_exist()
+    downloader.assert_called_once()


### PR DESCRIPTION
To reduce size of the packaged plugin, the models are now excluded from the build. Instead, they get pulled from github during initialization.

ref #31 